### PR TITLE
fix: correct PWA manifest theme_color to #404fa2

### DIFF
--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -13,7 +13,7 @@ export default function manifest(): MetadataRoute.Manifest {
     start_url: '/',
     display: 'standalone',
     background_color: '#ffffff',
-    theme_color: '#3344bc',
+    theme_color: '#404fa2',
     icons: [
       {
         src: '/icon-192.png',


### PR DESCRIPTION
Follow-up to #43. The PWA manifest `theme_color` was left at the earlier `#3344bc` when the brand color was corrected to `#404fa2` — the CSS accent and icon set were updated but the manifest value was missed. This aligns it.

Verified: build ✅, exported `manifest.webmanifest` now has `"theme_color":"#404fa2"`, type-check ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)